### PR TITLE
fix: `cha(cache).length` -> `cha(cache).len`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,7 +15,7 @@ function M:peek()
 
 	if self:preload() == 1 then
 		local cache = ya.file_cache(self)
-		if cache and fs.cha(cache).length > 0 then
+		if cache and fs.cha(cache).len > 0 then
 			image_height = ya.image_show(cache, self.area).h
 		end
 	end


### PR DESCRIPTION
fixes #3

I guess it would make sense to wait for a new `yazi` release that includes the commit introducing the issue before merging.

Making this backward compatible for 0.3.3 users would be even better but I have no idea how to achieve this.